### PR TITLE
Bug fix

### DIFF
--- a/ContentSheet/Classes/ContentSheet.swift
+++ b/ContentSheet/Classes/ContentSheet.swift
@@ -437,7 +437,7 @@ extension ContentSheet {
                                 
                                 switch finalState {
                                 case .expanded:
-                                    contentView.frame = CGRect(x: 0, y: 0, width: contentView.frame.width, height: self.expandedHeight)
+                                    contentView.frame = CGRect(x: 0, y: self.view.bounds.height - self.expandedHeight, width: contentView.frame.width, height: self.expandedHeight)
                                     break
                                 case .collapsed:
                                     contentView.frame = CGRect(x: 0, y: totalHeight - self.collapsedHeight, width: contentView.frame.width, height: max(contentView.frame.height, self.collapsedHeight))

--- a/Example/FKWidgetSheet/CustomContent.swift
+++ b/Example/FKWidgetSheet/CustomContent.swift
@@ -19,6 +19,12 @@ class CustomView: UIView {
         return .lightContent
     }
     
+    
+    func expandedHeight(containedIn contentSheet: ContentSheet) -> CGFloat {
+        return UIScreen.main.bounds.height*0.75
+    }
+    
+    
     static func customView() -> CustomView {
         let view = CustomView()
         view.backgroundColor = UIColor.magenta
@@ -26,9 +32,9 @@ class CustomView: UIView {
         return view
     }
     
-    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
-        self.dismissContentSheet(animated: true)
-    }
+//    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+//        self.dismissContentSheet(animated: true)
+//    }
 }
 
 
@@ -43,4 +49,8 @@ class CustomObject: NSObject, ContentSheetContentProtocol {
             return view
         }
     }
+    
+    func expandedHeight(containedIn contentSheet: ContentSheet) -> CGFloat {
+        return UIScreen.main.bounds.height*0.75
+    }    
 }

--- a/Example/FKWidgetSheet/SecondViewController.swift
+++ b/Example/FKWidgetSheet/SecondViewController.swift
@@ -57,7 +57,6 @@ class SecondViewController: UIViewController {
         return UIScreen.main.bounds.height*0.5
     }
     
-    //Returning the same height as collapsed height by default
     override open func expandedHeight(containedIn contentSheet: ContentSheet) -> CGFloat {
         return UIScreen.main.bounds.height
     }


### PR DESCRIPTION
If expanded height was less than full screen, there was a bug that caused content view to align top, showing empty space in bottom. That is fixed.